### PR TITLE
feature/48/compatibility with rails7

### DIFF
--- a/lib/remap/state.rb
+++ b/lib/remap/state.rb
@@ -3,7 +3,6 @@
 require "dry/schema"
 require "dry/validation"
 require "dry/core/constants"
-require "factory_bot"
 require "dry/logic"
 require "dry/logic/operations"
 require "dry/logic/predicates"

--- a/remap.gemspec
+++ b/remap.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.add_dependency "activesupport", "~> 6.1.4.1"
+  spec.add_dependency "activesupport", ">= 6.1.4.1", "< 8.0"
   spec.add_dependency "dry-core", "~> 0.7.1"
   spec.add_dependency "dry-initializer", "~> 3.0.4"
   spec.add_dependency "dry-interface", "~> 1.0.3"


### PR DESCRIPTION
This pull request relaxes the version constraint on activesupport to make it possible to use remap with rails v7.

Moreover a `require` statement for factory bot was removed from non-test code. If this statement was intentional, `factory_bot` should be added to the gemspec file as a dependency.